### PR TITLE
Register border palettes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
     cli,
     ggplot2,
     rlang,
+    scales,
     utils,
     vctrs
 RoxygenNote: 7.2.1

--- a/R/geom-borderpath.R
+++ b/R/geom-borderpath.R
@@ -435,6 +435,10 @@ set_border_palettes <- function() {
   }
 
   register_theme_elements(
+    palette.bordercolour.continuous = scales::pal_seq_gradient("#132B43", "#56B1F7"),
+    palette.bordercolour.discrete = scales::pal_hue(),
+    palette.borderwidth.continuous = scales::pal_rescale(c(1, 6)),
+    palette.borderwidth.discrete = function(n) seq(2, 6, length.out = n),
     element_tree = list(
       palette.bordercolour.continuous =
         el_def(c("character", "function"), "palette.colour.continuous"),

--- a/R/geom-borderpath.R
+++ b/R/geom-borderpath.R
@@ -424,3 +424,30 @@ scale_borderwidth_discrete <- function(..., aesthetics = "borderwidth") {
   out
 
 }
+
+set_border_palettes <- function() {
+  # Skip in old version
+  if (!"element_geom" %in% getNamespaceExports("ggplot2")) {
+    return()
+  }
+  new_pal <- function(inherit) {
+    el_def(c("character", "function"), inherit = inherit)
+  }
+
+  register_theme_elements(
+    element_tree = list(
+      palette.bordercolour.continuous =
+        el_def(c("character", "function"), "palette.colour.continuous"),
+      palette.bordercolour.discrete =
+        el_def(c("character", "function"), "palette.colour.discrete"),
+      palette.borderwidth.continuous =
+        el_def(c("character", "numeric", "integer", "function"), "palette.linewidth.continuous"),
+      palette.borderwidth.discrete =
+        el_def(c("character", "numeric", "integer", "function"), "palette.linewidth.discrete")
+    )
+  )
+}
+
+.onLoad <- function(...) {
+  set_border_palettes()
+}


### PR DESCRIPTION
Hi Jacob,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We found that the border scales don't come with default palettes, which is an issue in the new ggplot2 because these are dynamically looked up from the theme based on the aesthetic name.
This PR registers palettes for the aesthetics that ggborderline provides, which inherits from their sister-aesthetics.
This way, the palettes are looked up correctly again. 
Here is an example of how it works with theme-based palettes:

``` r
library(ggplot2)
devtools::load_all("~/packages/test/ggborderline/")
#> ℹ Loading ggborderline

ggplot(economics_long, aes(date, value01, bordercolour = variable)) +
  geom_borderline() +
  theme(palette.bordercolour.discrete = "viridis")
```

![](https://i.imgur.com/dRoZJw2.png)<!-- -->

<sup>Created on 2025-06-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit an update to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun

